### PR TITLE
Update rev to point to head of 'dev' branch.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -42,7 +42,7 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-edge"
         path="poky/meta-pelion-edge"
-        revision="refs/tags/2.1.0-1"
+        revision="refs/heads/dev"
         remote="github" />
 
     <project name="aaronovz1/meta-nodejs"


### PR DESCRIPTION
Pulls in fix that fixes the build, bit I have questions before merging this in, since I think this might need to be done in a certain way to follow the flow we currently have.

--

As I understand it, the intention for locking the ref to the release done in `meta-pelion-edge @ master` was to make sure that this repo's `dev` branch was stable, treating `meta-pelion-edge` as a component repo.

The down side to that is that there's no active testing being done against `meta-pelion-edge @ dev`, which is/could/should? be a problem because we want automated checks to run before merging in contributions (ie: like @esajaa iMX8 PR).

For now, this PR updates the ref to point to `meta-pelion-edge @ dev` branch, but if I understand how this should work, this shouldn't actually be merged and instead shoul actually point to `meta-pelion-edge @ master` when the fix lands in that branch and a patch release is made.

Does this all sound about right?