### PR TITLE
Updated meta-pelion-edge to point to fix branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -42,7 +42,7 @@
     <!-- software -->
     <project name="armpelionedge/meta-pelion-edge"
         path="poky/meta-pelion-edge"
-        revision="refs/tags/2.1.0-1"
+        revision="refs/tags/2.1.1"
         remote="github" />
 
     <project name="aaronovz1/meta-nodejs"


### PR DESCRIPTION
Fixes the build by pinning `pyopenssl` version within `meta-pelion-edge`.

Latest release was only a hotfix.